### PR TITLE
Dodge NPE during save()

### DIFF
--- a/src/main/java/org/wyldmods/simpleachievements/common/data/DataManager.java
+++ b/src/main/java/org/wyldmods/simpleachievements/common/data/DataManager.java
@@ -221,7 +221,7 @@ public class DataManager
 
     public void save()
     {
-        if (!noSave)
+        if (!noSave && saveFile != null)
         {
             saveMap(saveFile, this, this.map);
         }


### PR DESCRIPTION
If load() fails before saveFile is set, or load() never gets called, saveFile can be null during save(). In either case, the world wasn't loaded, so saving seems safe to skip.

Fixes #22.